### PR TITLE
Misc Model and Texture fixes/improvements

### DIFF
--- a/GameResources.cs
+++ b/GameResources.cs
@@ -118,6 +118,19 @@ namespace Chisel.Import.Source.VPKTools
 			return sourceText;
 		}
 
+		public VTF ImportVTF(string entryName)
+		{
+			if (entryName == null)
+				return null;
+			// TODO: use PackagePath instead
+			var rentedCharList = ArrayPool<char>.Shared.Rent(255);
+			entryName = CleanedKeyname(entryName, 0, rentedCharList, out int extensionstart);
+			ArrayPool<char>.Shared.Return(rentedCharList);
+			if (entryName == null || !lookup.TryGetValue(entryName, out var entry))
+				return null;
+			return ImportVTF(entry);
+		}
+
 		public VTF ImportVTF(GameEntry entry)
 		{
 			VTF sourceTexture = null;
@@ -127,6 +140,19 @@ namespace Chisel.Import.Source.VPKTools
 				return true;
 			})) return null;
 			return sourceTexture;
+		}
+
+		public VmfMaterial ImportVmf(string entryName)
+		{
+			if (entryName == null)
+				return null;
+			// TODO: use PackagePath instead
+			var rentedCharList = ArrayPool<char>.Shared.Rent(255);
+			entryName = CleanedKeyname(entryName, 0, rentedCharList, out int extensionstart);
+			ArrayPool<char>.Shared.Return(rentedCharList);
+			if (entryName == null || !lookup.TryGetValue(entryName, out var entry))
+				return null;
+			return ImportVmf(entry);
 		}
 
 		public VmfMaterial ImportVmf(GameEntry entry)
@@ -141,6 +167,19 @@ namespace Chisel.Import.Source.VPKTools
 				return null;
 			}
 			return sourceMaterial;
+		}
+
+		public MdlHeader ImportMdl(string entryName, Lookup _lookup)
+		{
+			if (entryName == null)
+				return null;
+			// TODO: use PackagePath instead
+			var rentedCharList = ArrayPool<char>.Shared.Rent(255);
+			entryName = CleanedKeyname(entryName, 0, rentedCharList, out int extensionstart);
+			ArrayPool<char>.Shared.Return(rentedCharList);
+			if (entryName == null || !lookup.TryGetValue(entryName, out var entry))
+				return null;
+			return ImportMdl(entry, _lookup);
 		}
 
 		public MdlHeader ImportMdl(GameEntry entry, Lookup lookup)
@@ -167,6 +206,19 @@ namespace Chisel.Import.Source.VPKTools
 			return header;
 		}
 
+		public VtxHeader ImportVtx(string entryName)
+		{
+			if (entryName == null)
+				return null;
+			// TODO: use PackagePath instead
+			var rentedCharList = ArrayPool<char>.Shared.Rent(255);
+			entryName = CleanedKeyname(entryName, 0, rentedCharList, out int extensionstart);
+			ArrayPool<char>.Shared.Return(rentedCharList);
+			if (entryName == null || !lookup.TryGetValue(entryName, out var entry))
+				return null;
+			return ImportVtx(entry);
+		}
+
 		public VtxHeader ImportVtx(GameEntry entry)
 		{
 			if (entry.Extension != PackagePath.VtxExtension)
@@ -182,6 +234,19 @@ namespace Chisel.Import.Source.VPKTools
 				return true;
 			})) return null;
 			return header;
+		}
+
+		public VvdHeader ImportVvd(string entryName, MdlHeader mdlHeader)
+		{
+			if (entryName == null)
+				return null;
+			// TODO: use PackagePath instead
+			var rentedCharList = ArrayPool<char>.Shared.Rent(255);
+			entryName = CleanedKeyname(entryName, 0, rentedCharList, out int extensionstart);
+			ArrayPool<char>.Shared.Return(rentedCharList);
+			if (entryName == null || !lookup.TryGetValue(entryName, out var entry))
+				return null;
+			return ImportVvd(entry, mdlHeader);
 		}
 
 		public VvdHeader ImportVvd(GameEntry entry, MdlHeader mdlHeader)

--- a/GameResources.cs
+++ b/GameResources.cs
@@ -269,7 +269,9 @@ namespace Chisel.Import.Source.VPKTools
 					case PackagePath.VtfExtension:
 					{
 						VTF sourceTexture = VTF.Read(stream);
-						foundAsset = Texture2DImporter.Import(sourceTexture, outputPath);
+						var foundAssets = Texture2DImporter.Import(sourceTexture, outputPath);
+						if (foundAssets != null)
+							foundAsset = foundAssets[0]; // TODO: handle frames better
 						return foundAsset != null;
 					}
 					default:

--- a/GameResources.cs
+++ b/GameResources.cs
@@ -85,22 +85,7 @@ namespace Chisel.Import.Source.VPKTools
 		{
 			entryName = entryName.Replace('\\', '/').ToLower();
 			string fullname = Path.ChangeExtension($"materials/{entryName}", PackagePath.VtfExtension);
-			return ImportGetEntry<Texture2D>(fullname);
-		}
-
-		public T ImportGetEntry<T>(string entryName) where T : UnityEngine.Object
-		{
-			if (entryName == null)
-				return null;
-			// TODO: use PackagePath instead
-			var rentedCharList = ArrayPool<char>.Shared.Rent(255);
-			entryName = CleanedKeyname(entryName, 0, rentedCharList, out int extensionstart);
-			ArrayPool<char>.Shared.Return(rentedCharList);
-			if (entryName == null || !lookup.TryGetValue(entryName, out var entry))
-				return null;
-			if (!Import<T>(entry, out var asset))
-				return null;
-			return asset;
+			return Import<Texture2D>(fullname);
 		}
 
 
@@ -118,7 +103,7 @@ namespace Chisel.Import.Source.VPKTools
 			return sourceText;
 		}
 
-		public VTF ImportVTF(string entryName)
+		public VTF LoadVTF(string entryName)
 		{
 			if (entryName == null)
 				return null;
@@ -128,10 +113,10 @@ namespace Chisel.Import.Source.VPKTools
 			ArrayPool<char>.Shared.Return(rentedCharList);
 			if (entryName == null || !lookup.TryGetValue(entryName, out var entry))
 				return null;
-			return ImportVTF(entry);
+			return LoadVTF(entry);
 		}
 
-		public VTF ImportVTF(GameEntry entry)
+		public VTF LoadVTF(GameEntry entry)
 		{
 			VTF sourceTexture = null;
 			if (!LoadFileAsStream(entry, delegate (Stream stream)
@@ -142,7 +127,7 @@ namespace Chisel.Import.Source.VPKTools
 			return sourceTexture;
 		}
 
-		public VmfMaterial ImportVmf(string entryName)
+		public VmfMaterial LoadVmf(string entryName)
 		{
 			if (entryName == null)
 				return null;
@@ -152,10 +137,10 @@ namespace Chisel.Import.Source.VPKTools
 			ArrayPool<char>.Shared.Return(rentedCharList);
 			if (entryName == null || !lookup.TryGetValue(entryName, out var entry))
 				return null;
-			return ImportVmf(entry);
+			return LoadVmf(entry);
 		}
 
-		public VmfMaterial ImportVmf(GameEntry entry)
+		public VmfMaterial LoadVmf(GameEntry entry)
 		{
 			VmfMaterial sourceMaterial = null; 
 			if (!LoadFileAsStream(entry, delegate (Stream stream)
@@ -169,7 +154,7 @@ namespace Chisel.Import.Source.VPKTools
 			return sourceMaterial;
 		}
 
-		public MdlHeader ImportMdl(string entryName, Lookup _lookup)
+		public MdlHeader LoadMdl(string entryName, Lookup _lookup)
 		{
 			if (entryName == null)
 				return null;
@@ -179,10 +164,10 @@ namespace Chisel.Import.Source.VPKTools
 			ArrayPool<char>.Shared.Return(rentedCharList);
 			if (entryName == null || !lookup.TryGetValue(entryName, out var entry))
 				return null;
-			return ImportMdl(entry, _lookup);
+			return LoadMdl(entry, _lookup);
 		}
 
-		public MdlHeader ImportMdl(GameEntry entry, Lookup lookup)
+		public MdlHeader LoadMdl(GameEntry entry, Lookup lookup)
 		{
 			if (entry.Extension != PackagePath.MdlExtension)
 				return null;
@@ -192,8 +177,6 @@ namespace Chisel.Import.Source.VPKTools
 			{
 				if (!LoadFileAsStream(entry, delegate (Stream stream)
 				{
-					var outputPath = GetOutputPath(entry.keyname);
-					PackagePath.EnsureDirectoriesExist(outputPath);
 					using var reader = new BinaryReader(stream);
 					header = MdlHeader.Read(reader, this, lookup);
 					return true;
@@ -206,7 +189,7 @@ namespace Chisel.Import.Source.VPKTools
 			return header;
 		}
 
-		public VtxHeader ImportVtx(string entryName)
+		public VtxHeader LoadVtx(string entryName)
 		{
 			if (entryName == null)
 				return null;
@@ -216,10 +199,10 @@ namespace Chisel.Import.Source.VPKTools
 			ArrayPool<char>.Shared.Return(rentedCharList);
 			if (entryName == null || !lookup.TryGetValue(entryName, out var entry))
 				return null;
-			return ImportVtx(entry);
+			return LoadVtx(entry);
 		}
 
-		public VtxHeader ImportVtx(GameEntry entry)
+		public VtxHeader LoadVtx(GameEntry entry)
 		{
 			if (entry.Extension != PackagePath.VtxExtension)
 				return null;
@@ -227,8 +210,6 @@ namespace Chisel.Import.Source.VPKTools
 			VtxHeader header = null;
 			if (!LoadFileAsStream(entry, delegate (Stream stream)
 			{
-				var outputPath = GetOutputPath(entry.keyname);
-				PackagePath.EnsureDirectoriesExist(outputPath);
 				using var reader = new BinaryReader(stream);
 				header = VtxHeader.Read(reader);
 				return true;
@@ -236,7 +217,7 @@ namespace Chisel.Import.Source.VPKTools
 			return header;
 		}
 
-		public VvdHeader ImportVvd(string entryName, MdlHeader mdlHeader)
+		public VvdHeader LoadVvd(string entryName, MdlHeader mdlHeader)
 		{
 			if (entryName == null)
 				return null;
@@ -246,10 +227,10 @@ namespace Chisel.Import.Source.VPKTools
 			ArrayPool<char>.Shared.Return(rentedCharList);
 			if (entryName == null || !lookup.TryGetValue(entryName, out var entry))
 				return null;
-			return ImportVvd(entry, mdlHeader);
+			return LoadVvd(entry, mdlHeader);
 		}
 
-		public VvdHeader ImportVvd(GameEntry entry, MdlHeader mdlHeader)
+		public VvdHeader LoadVvd(GameEntry entry, MdlHeader mdlHeader)
 		{
 			if (entry.Extension != PackagePath.VvdExtension)
 				return null;
@@ -257,8 +238,6 @@ namespace Chisel.Import.Source.VPKTools
 			VvdHeader header = null;
 			if (!LoadFileAsStream(entry, delegate (Stream stream)
 			{
-				var outputPath = GetOutputPath(entry.keyname);
-				PackagePath.EnsureDirectoriesExist(outputPath);
 				using var reader = new BinaryReader(stream);
 				header = VvdHeader.Load(reader, mdlHeader);
 				return true;
@@ -271,7 +250,7 @@ namespace Chisel.Import.Source.VPKTools
 			var lookup = new Lookup();
 
 			var mdlEntry = GetEntry(modelId);
-			var mdlHeader = mdlEntry != null ? ImportMdl(mdlEntry, lookup) : null;
+			var mdlHeader = mdlEntry != null ? LoadMdl(mdlEntry, lookup) : null;
 			if (mdlHeader == null)
 			{
 				Debug.LogError($"Failed to load mdlHeader {modelId}");
@@ -280,7 +259,7 @@ namespace Chisel.Import.Source.VPKTools
 
 			var vvdHeaderName = Path.ChangeExtension(modelId, PackagePath.VvdExtension);
 			var vvdEntry = GetEntry(vvdHeaderName);
-			var vvdHeader = (vvdEntry != null) ? ImportVvd(vvdEntry, mdlHeader) : null;
+			var vvdHeader = (vvdEntry != null) ? LoadVvd(vvdEntry, mdlHeader) : null;
 			if (vvdHeader == null)
 			{
 				Debug.LogError($"Failed to load vvdHeader {vvdHeaderName}");
@@ -289,7 +268,7 @@ namespace Chisel.Import.Source.VPKTools
 
 			var vtxHeaderName = Path.ChangeExtension(modelId, PackagePath.VtxDX90Extension);
 			var vtxEntry = GetEntry(vtxHeaderName);
-			var vtxHeader = (vtxEntry != null) ? ImportVtx(vtxEntry) : null;
+			var vtxHeader = (vtxEntry != null) ? LoadVtx(vtxEntry) : null;
 			if (vtxHeader == null)
 			{
 				Debug.LogError($"Failed to load vtxHeader {vtxHeaderName}");
@@ -310,6 +289,21 @@ namespace Chisel.Import.Source.VPKTools
 			};
 		}
 
+
+		public T Import<T>(string entryName) where T : UnityEngine.Object
+		{
+			if (entryName == null)
+				return null;
+			// TODO: use PackagePath instead
+			var rentedCharList = ArrayPool<char>.Shared.Rent(255);
+			entryName = CleanedKeyname(entryName, 0, rentedCharList, out int extensionstart);
+			ArrayPool<char>.Shared.Return(rentedCharList);
+			if (entryName == null || !lookup.TryGetValue(entryName, out var entry))
+				return null;
+			if (!Import<T>(entry, out var asset))
+				return null;
+			return asset;
+		}
 
 		public bool Import<T>(GameEntry entry, out T asset) where T : UnityEngine.Object
 		{

--- a/Unity/Helpers/Texture2DHelpers.cs
+++ b/Unity/Helpers/Texture2DHelpers.cs
@@ -7,7 +7,6 @@ using UnityEngine;
 
 namespace Chisel.Import.Source.VPKTools
 {
-    // TODO: separate the unity specific functions from those that simply work on an array of colors
     public static class Texture2DHelpers
     {
         /// <summary>

--- a/Unity/Helpers/Texture2DHelpers.cs
+++ b/Unity/Helpers/Texture2DHelpers.cs
@@ -1,4 +1,4 @@
-﻿using Chisel.Import.Source.VPKTools.Helpers;
+using Chisel.Import.Source.VPKTools.Helpers;
 
 using System;
 using System.IO;
@@ -68,7 +68,7 @@ namespace Chisel.Import.Source.VPKTools
         /// <param name="height">Expected height of the image</param>
         /// <param name="textureFormat">The format of the data given</param>
         /// <returns>Pixel color data</returns>
-        public static Color[] DecompressRawBytes( Stream data, ushort width, ushort height, TextureFormat textureFormat )
+        public static Color[] DecompressRawBytes( Stream data, ushort width, ushort height, uint dataSize, TextureFormat textureFormat )
         {
             Color[] colors = null;
             if( textureFormat == TextureFormat.BGR888 )
@@ -76,11 +76,11 @@ namespace Chisel.Import.Source.VPKTools
             else if( textureFormat == TextureFormat.BGRA8888 )
                 colors = DecompressBGRA8888( data, width, height );
             else if( textureFormat == TextureFormat.DXT1 )
-                colors = DecompressDXT1( data, width, height );
+                colors = DecompressDXT1( data, width, height, dataSize);
             else if( textureFormat == TextureFormat.DXT3 )
-                colors = DecompressDXT3( data, width, height );
+                colors = DecompressDXT3( data, width, height, dataSize);
             else if( textureFormat == TextureFormat.DXT5 )
-                colors = DecompressDXT5( data, width, height );
+                colors = DecompressDXT5( data, width, height, dataSize);
             else
                 Debug.LogError( "Texture2DHelpers: Texture format not supported " + textureFormat );
 
@@ -172,8 +172,8 @@ namespace Chisel.Import.Source.VPKTools
         /// <param name="width">Expected width of the image</param>
         /// <param name="height">Expected height of the image</param>
         /// <returns>Pixel color data</returns>
-        public static Color[] DecompressDXT1( Stream data, ushort width, ushort height )
-        {
+        public static Color[] DecompressDXT1(Stream data, ushort width, ushort height, uint dataSize)
+		{
             Color[] texture2DColors = new Color[width * height];
 
             for( int row = 0; row < height; row += 4 )
@@ -216,17 +216,17 @@ namespace Chisel.Import.Source.VPKTools
             }
 
             return texture2DColors.ToArray();
-        }
+		}
 
-        /// <summary>
-        /// Turn raw DXT3 bytes to a Color array that can be used in a Texture2D.
-        /// </summary>
-        /// <param name="data">Raw image byte data</param>
-        /// <param name="width">Expected width of the image</param>
-        /// <param name="height">Expected height of the image</param>
-        /// <returns>Pixel color data</returns>
-        public static Color[] DecompressDXT3( Stream data, ushort width, ushort height )
-        {
+		/// <summary>
+		/// Turn raw DXT3 bytes to a Color array that can be used in a Texture2D.
+		/// </summary>
+		/// <param name="data">Raw image byte data</param>
+		/// <param name="width">Expected width of the image</param>
+		/// <param name="height">Expected height of the image</param>
+		/// <returns>Pixel color data</returns>
+		public static Color[] DecompressDXT3( Stream data, ushort width, ushort height, uint dataSize)
+		{
             Color[] texture2DColors = new Color[width * height];
 
             for( int row = 0; row < height; row += 4 )
@@ -279,8 +279,18 @@ namespace Chisel.Import.Source.VPKTools
         /// <param name="width">Expected width of the image</param>
         /// <param name="height">Expected height of the image</param>
         /// <returns>Pixel color data</returns>
-        public static Color[] DecompressDXT5( Stream data, ushort width, ushort height )
-        {
+        public static Color[] DecompressDXT5( Stream data, ushort width, ushort height, uint dataSize)
+		{
+			// TODO: replace this with our own DXT5 decompression code
+			var byteBuffer = new byte[dataSize];
+			data.Read(byteBuffer, 0, byteBuffer.Length);
+
+			Texture2D tex = new(width, height, UnityEngine.TextureFormat.DXT5, false, false, true);
+			tex.LoadRawTextureData(byteBuffer);
+			var pixels = tex.GetPixels();
+			UnityEngine.Object.DestroyImmediate(tex);
+			return pixels;
+#if false
             Color[] texture2DColors = new Color[width * height];
 
             for( int row = 0; row < height; row += 4 )
@@ -370,7 +380,8 @@ namespace Chisel.Import.Source.VPKTools
             }
 
             return texture2DColors.ToArray();
-        }
+#endif
+		}
 
         /// <summary>
         /// This enum only holds the formats this helper class can read.

--- a/Unity/MaterialImporter.cs
+++ b/Unity/MaterialImporter.cs
@@ -173,9 +173,6 @@ namespace Chisel.Import.Source.VPKTools
 			if (unityMaterial.HasProperty("_Glossiness")) unityMaterial.SetFloat("_Glossiness", 0);
 			if (unityMaterial.HasProperty("_SmoothnessTextureChannel")) unityMaterial.SetInt("_SmoothnessTextureChannel", 0);
 
-
-			// TODO: support multiple frames
-
 			Texture2D mainTexture = SetMaterialTexture(resources, unityMaterial, "_MainTex", sourceMaterial.BaseTextureName);
 			Texture2D normalMap = SetMaterialTexture(resources, unityMaterial, "_BumpMap", sourceMaterial.BumpMapName);
 			Texture2D selfIlluminationMap = SetMaterialTexture(resources, unityMaterial, "_EmissionMap", sourceMaterial.SelfIlluminationTexture);
@@ -274,10 +271,6 @@ namespace Chisel.Import.Source.VPKTools
 
 			if (sourceMaterial.Color != null)
 				unityMaterial.SetColor("_Color", sourceMaterial.Color);
-
-			// TODO: support BumpmapScale
-			//if (normalMap != null)
-			//	unityMaterial.SetFloat("_BumpScale", normalMap.BumpmapScale);
 
 			if (haveCutout && sourceMaterial.AlphaTestReference.HasValue)
 				unityMaterial.SetFloat("_Cutoff", sourceMaterial.AlphaTestReference.Value);

--- a/Unity/MdlModelImporter.cs
+++ b/Unity/MdlModelImporter.cs
@@ -574,19 +574,21 @@ namespace Chisel.Import.Source.VPKTools
 													indexLookup[vertex3] = index3;
 												}
 
+												#pragma warning disable CS0162 // Unreachable code detected
 												if (SourceEngineUnits.InvertPlanes)
 												{
 													meshEntry.Indices.Add(index1);
 													meshEntry.Indices.Add(index3);
 													meshEntry.Indices.Add(index2);
 												} else
-												{ 
+												{
 													meshEntry.Indices.Add(index1);
 													meshEntry.Indices.Add(index2);
 													meshEntry.Indices.Add(index3);
 												}
+												#pragma warning restore CS0162 // Unreachable code detected
 											}
-											
+
 											if (isDoubleSided)
 											{
 												if (!inverseIndexLookup.TryGetValue(vertex1, out int index1)) index1 = -1;
@@ -625,7 +627,8 @@ namespace Chisel.Import.Source.VPKTools
 													if (tangents != null) modelEntry.Tangents.Add(-tangents[vertex2]);
 													inverseIndexLookup[vertex2] = index2;
 												}
-
+												
+												#pragma warning disable CS0162 // Unreachable code detected
 												if (SourceEngineUnits.InvertPlanes)
 												{
 													meshEntry.Indices.Add(index1);
@@ -637,6 +640,7 @@ namespace Chisel.Import.Source.VPKTools
 													meshEntry.Indices.Add(index2);
 													meshEntry.Indices.Add(index3);
 												}
+												#pragma warning restore CS0162 // Unreachable code detected
 											}
 										}
 									}

--- a/Unity/MdlModelImporter.cs
+++ b/Unity/MdlModelImporter.cs
@@ -295,11 +295,16 @@ namespace Chisel.Import.Source.VPKTools
 				else
 					ArrayUtility.Add(ref lod.renderers, renderer);
 
-				// TODO: improve on this
 				lod.screenRelativeTransitionHeight = 1.0f / (2.0f + (modelEntry.LodIndex * 3));// SourceEngineUnits.VmfLodSwitchpointToUnityLodTransition(modelEntry.SwitchPoint);
 				lods[modelEntry.LodIndex] = lod;
 			}
-			if (lodGroup != null)
+			if (lods != null && lods.Count > 0)
+			{
+				var lastLod = lods[lods.Count];
+				lastLod.screenRelativeTransitionHeight = 1.0f;
+				lods[lods.Count] = lastLod;
+			}
+ 			if (lodGroup != null)
 				lodGroup.SetLODs(lods.ToArray());
 		}
 

--- a/Unity/Texture2DImporter.cs
+++ b/Unity/Texture2DImporter.cs
@@ -16,7 +16,7 @@ namespace Chisel.Import.Source.VPKTools
 			if (foundAsset != null)
 				return new Texture2D[] { foundAsset };
 
-			var filePath = Path.ChangeExtension(outputPath, "[0].png");
+			var filePath = Path.Combine(Path.GetDirectoryName(outputPath), Path.GetFileNameWithoutExtension(outputPath) + "[0].png");
 			foundAsset = UnityAssets.Load<Texture2D>(filePath);
 			if (foundAsset != null)
 			{
@@ -26,7 +26,7 @@ namespace Chisel.Import.Source.VPKTools
 				{
 					frameTextureList.Add(foundAsset);
 					index++;
-					filePath = Path.ChangeExtension(outputPath, $"[{index}].png");
+					filePath = Path.Combine(Path.GetDirectoryName(outputPath), Path.GetFileNameWithoutExtension(outputPath) + $"[{index}].png");
 					foundAsset = UnityAssets.Load<Texture2D>(filePath);
 				}
 				return frameTextureList.ToArray();
@@ -80,7 +80,7 @@ namespace Chisel.Import.Source.VPKTools
 					UnityEngine.Experimental.Rendering.GraphicsFormat.R32G32B32A32_SFloat,
 					(uint)texture.Width, (uint)texture.Height);
 
-				var filePath = Path.ChangeExtension(destinationPath, $"[{i}].png");
+				var filePath = Path.Combine(Path.GetDirectoryName(destinationPath), Path.GetFileNameWithoutExtension(destinationPath) + $"[{i}].png");
 				frameNames[i] = filePath;
 				File.WriteAllBytes(filePath, bytes);
 			}

--- a/Unity/Texture2DImporter.cs
+++ b/Unity/Texture2DImporter.cs
@@ -13,40 +13,28 @@ namespace Chisel.Import.Source.VPKTools
 			var foundAsset = UnityAssets.Load<Texture2D>(destinationPath);
 			if (foundAsset != null)
 				return foundAsset;
-
-			// Convert vtf texture to unity Texture2D
-			if (!CopyToTexture(sourceTexture, out Texture2D unityTexture) ||
-				unityTexture == null)
-			{
-				return null;
-			}
-
-			try
-			{
-				// Write texture as a png file
-				SavePng(unityTexture, destinationPath);
-
-				// Import png file as an asset
-				var assetPath = UnityAssets.GetAssetPath(destinationPath);
-				AssetDatabase.ImportAsset(assetPath, ImportAssetOptions.ForceSynchronousImport | ImportAssetOptions.ForceUncompressedImport);
 			
-				// Configure the importer (can only be done after importing once) and re-import
-				ConfigureTextureImporter(sourceTexture, assetPath);
+			// Write texture as a png file
+			SavePng(sourceTexture, destinationPath);
 
-				// Reload the asset
-				return AssetDatabase.LoadAssetAtPath<Texture2D>(assetPath);
-			}
-			finally
-			{
-				// make sure we destroy the Texture2D we created, so it doesn't end up stored in our scene file
-				UnityEngine.Object.DestroyImmediate(unityTexture);
-			}
+			// Import png file as an asset
+			var assetPath = UnityAssets.GetAssetPath(destinationPath);
+			AssetDatabase.ImportAsset(assetPath, ImportAssetOptions.ForceSynchronousImport | ImportAssetOptions.ForceUncompressedImport);
+			
+			// Configure the importer (can only be done after importing once) and re-import
+			ConfigureTextureImporter(sourceTexture, assetPath);
+
+			// Reload the asset
+			return AssetDatabase.LoadAssetAtPath<Texture2D>(assetPath);
 		}
 
-		public static void SavePng(Texture2D unityTexture, string destinationPath)
+		public static void SavePng(VTF texture, string destinationPath)
 		{
 			PackagePath.EnsureDirectoriesExist(destinationPath);
-			var bytes = ImageConversion.EncodeToPNG(unityTexture);
+			var bytes = ImageConversion.EncodeArrayToPNG(texture.Pixels,
+				//UnityEngine.Experimental.Rendering.GraphicsFormat.R8G8B8A8_UNorm, 
+				UnityEngine.Experimental.Rendering.GraphicsFormat.R32G32B32A32_SFloat,
+				(uint)texture.Width, (uint)texture.Height);
 			File.WriteAllBytes(destinationPath, bytes);
 		}
 

--- a/ValveMaterialFormat/VMF.cs
+++ b/ValveMaterialFormat/VMF.cs
@@ -23,6 +23,7 @@ namespace Chisel.Import.Source.VPKTools
 		public bool?		BumpSelfShadowing;
 		public string       BumpMapName;
 		public string       BumpMap2Name;
+		public string       BumpMap3Name;
 		public int?			BumpFrame;
 		
 		public string       NormalMapName;
@@ -95,6 +96,7 @@ namespace Chisel.Import.Source.VPKTools
 			if (BaseTexture2Name != null) outputTextureNames.Add(BaseTexture2Name);
 			if (BumpMapName != null) outputTextureNames.Add(BumpMapName);
 			if (BumpMap2Name != null) outputTextureNames.Add(BumpMap2Name);
+			if (BumpMap3Name != null) outputTextureNames.Add(BumpMap3Name);
 			if (NormalMapName != null) outputTextureNames.Add(NormalMapName);
 
 			if (SelfIlluminationMask != null) outputTextureNames.Add(SelfIlluminationMask);
@@ -302,12 +304,6 @@ namespace Chisel.Import.Source.VPKTools
 						case "$bloomexponent": // '3'.
 						case "$bloomsaturation": // '1'.
 						case "$bloomscale": // '1'.
-											//case "$bloomtexture": // '_rt_fullframefb2'.
-											//case "$bloomtexture": // '_rt_small16fb0'.
-											//case "$bloomtexture": // '_rt_small2fb0'.
-											//case "$bloomtexture": // '_rt_smallfb0'.
-											//case "$bloomtexture": // '_rt_smallfb2'.
-											//case "$bloomtexture": // '_rt_smallhdr0'.
 						case "$bloomtexture": // '_rt_small8fb0'.
 						case "$bloomtintenable": // '1'. '2'.
 						case "$bloomtype": // '0'.
@@ -316,18 +312,16 @@ namespace Chisel.Import.Source.VPKTools
 						case "$blurtexture": // '_rt_smallhdr0'.
 						case "$bottommaterial":
 						case "$brightness": // 'effects/spark_brightness'.
-						case "$bumpamp":
 						case "$bumpbasetexture2withbumpmap": // '0'. '1'.
-						case "$bumpmap3": // 'models/boxrocket_chell_head/face_1.0_n'.
-						case "$bumpmaptransform": // 'center 1.0 1.0 scale 2.0 2.0 rotate 0.0 translate 0.5 0.5'.
 						case "$bumpoffset":
 						case "$bumpscale": // '0.25'. '0.50'.
 						case "$bumpstretch": // 'models/shadertest/shader1_normal'.
-											 //case "$bumptransform": // 'center .75 .75 scale 2 2 rotate 0 translate 0 0'.
-											 //case "$bumptransform": // 'center 0 0 scale 2 2 rotate 0 translate 0 0'.
-											 //case "$bumptransform": // 'center 1 1 scale 2 2 rotate 0 translate .50 0'.
-											 //case "$bumptransform": // 'center 1 1 scale 2 2 rotate 0 translate 0 0'.
+						//case "$bumptransform": // 'center .75 .75 scale 2 2 rotate 0 translate 0 0'.
+						//case "$bumptransform": // 'center 0 0 scale 2 2 rotate 0 translate 0 0'.
+						//case "$bumptransform": // 'center 1 1 scale 2 2 rotate 0 translate .50 0'.
+						//case "$bumptransform": // 'center 1 1 scale 2 2 rotate 0 translate 0 0'.
 						case "$bumptransform": // '[ 1.000000 0.000000 0.000000 0.000000 0.000000 1.000000 0.000000 0.000000 0.000000 0.000000 1.000000 0.000000 0.000000 0.000000 0.000000 1.000000 ]'.
+						case "$bumpmaptransform": // 'center 1.0 1.0 scale 2.0 2.0 rotate 0.0 translate 0.5 0.5'.
 						case "$bumpwrinkle": // 'models/shadertest/shader3_normal'.
 						case "$burn_grad": // 'dev/vortex_burn_grad_1d'.
 						case "$burn_noise": // 'dev/burnableweb3_mask'. 'dev/xognoise'.
@@ -1105,8 +1099,10 @@ namespace Chisel.Import.Source.VPKTools
 						case "$basealphaenvmapmask": { TryParseFloatProperty(property, ref vmfMaterial.BaseAlphaEnvMapMask); break; }
 
 						case "$bumpframe": { TryParseIntProperty(property, ref vmfMaterial.BumpFrame); break; }
+						case "$bumpamp":
 						case "$bumpmap": { vmfMaterial.BumpMapName = property.Value; break; }
 						case "$bumpmap2": { vmfMaterial.BumpMap2Name = property.Value; break; }
+						case "$bumpmap3": { vmfMaterial.BumpMap3Name = property.Value; break; }
 
 						case "$ssbump2": // '1'.
 						case "$ssbumpmathfix": // '1'.

--- a/ValveMaterialFormat/VMF.cs
+++ b/ValveMaterialFormat/VMF.cs
@@ -81,6 +81,14 @@ namespace Chisel.Import.Source.VPKTools
 		public float?       AlphaTestReference;
 		public bool?		AlphaTest;
 
+
+		public bool HaveCutout { get { return AlphaTest.HasValue && AlphaTest.Value; } }
+		public bool HaveTranslucency { get { return Translucent.HasValue && Translucent.Value; } }
+		public bool HaveAdditiveBlending { get { return Additive.HasValue && (Additive.Value > 0); } }
+		public bool HaveTransparency { get { return HaveTranslucency || HaveAdditiveBlending || HaveCutout; } }
+
+
+
 		public void GetAllTextureNames(HashSet<string> outputTextureNames)
 		{
 			if (BaseTextureName != null) outputTextureNames.Add(BaseTextureName);

--- a/ValveModelFormat/Structs/MdlHeader.cs
+++ b/ValveModelFormat/Structs/MdlHeader.cs
@@ -157,6 +157,7 @@ namespace Chisel.Import.Source.VPKTools
 		public static StudioQuaternionInterpolateInfo[] Load(BinaryReader reader, Lookup lookup, int count, long offset)
 		{
 			return null;
+			#if false
 			// TODO: figure out why this is broken
 			StudioQuaternionInterpolateInfo[] items;
 			try
@@ -181,6 +182,7 @@ namespace Chisel.Import.Source.VPKTools
 
 			reader.BaseStream.Seek(startSeek, SeekOrigin.Begin);
 			return items;
+			#endif
 		}
 	};
 
@@ -952,7 +954,8 @@ namespace Chisel.Import.Source.VPKTools
 		{
 			//if (offset == 0)
 				return new StudioAnimation[0];
-				
+
+			#if false
 			var items = new List<StudioAnimation>();
 			var startSeek = reader.BaseStream.Position;
 			var currentOffset = offset;
@@ -974,6 +977,7 @@ namespace Chisel.Import.Source.VPKTools
 
 			reader.BaseStream.Seek(startSeek, SeekOrigin.Begin);
 			return items.ToArray();
+			#endif
 		}
 	};
 		

--- a/ValveModelFormat/Structs/MdlHeader.cs
+++ b/ValveModelFormat/Structs/MdlHeader.cs
@@ -2153,7 +2153,7 @@ namespace Chisel.Import.Source.VPKTools
 				var mdlEntry = gameResources.GetEntry(items[i].name);
 				if (mdlEntry != null)
 				{
-					items[i].header = gameResources.ImportMdl(mdlEntry, lookup);
+					items[i].header = gameResources.LoadMdl(mdlEntry, lookup);
 				}
 				else
 					items[i].header = null;

--- a/ValveTextureFormat/Structs/VTFHeader.cs
+++ b/ValveTextureFormat/Structs/VTFHeader.cs
@@ -57,9 +57,9 @@
         public       VTFImageFlag   flags;                  // VTF flags.
         public       ushort         frames;                 // Number of frames, if animated (1 for no animation).
         public       ushort         firstFrame;             // First frame in animation (0 based).
-        public       byte[]         padding0;               // (Sizeof 4) reflectivity padding (16 byte alignment).
+        public       uint           padding0;               // (Sizeof 4) reflectivity padding (16 byte alignment).
         public       float[]        reflectivity;           // (Sizeof 3) reflectivity vector.
-        public       byte[]         padding1;               // (Sizeof 4) reflectivity padding (8 byte packing).
+        public       uint           padding1;               // (Sizeof 4) reflectivity padding (8 byte packing).
         public       float          bumpmapScale;           // Bumpmap scale.
         public       VTFImageFormat highResImageFormat;     // High resolution image format.
         public       byte           mipmapCount;            // Number of mipmaps.

--- a/ValveTextureFormat/VTF.cs
+++ b/ValveTextureFormat/VTF.cs
@@ -8,7 +8,6 @@ namespace Chisel.Import.Source.VPKTools
 {
     public class VTF
     {
-        public static bool averageTextures = false;
         public static int  maxTextureSize  = 4096;
 
 		public Frame[] Frames       { get; private set; }
@@ -26,26 +25,12 @@ namespace Chisel.Import.Source.VPKTools
         public static VTF Read( Stream stream )
         {
 			var frames = LoadVTFFile(stream, out int width, out int height, out var flags, out var hasAlpha);
-			
-            // TODO: why? when we export textures and import them through unity, unity can handle this for us?
-			/*
-			if (pixels != null)
-            {
-                if (averageTextures)
-                {
-                    pixels = MakePlain( AverageTexture( pixels ), 4, 4 );
-                    width  = 4;
-                    height = 4;
-                } else
-                    pixels = DecreaseTextureSize( pixels, width, height, maxTextureSize, out width, out height );
-            }*/
-
 			return new VTF
 			{
-				Frames = frames,
-				Width  = width,
-				Height = height,
-				Flags = flags,
+				Frames   = frames,
+				Width    = width,
+				Height   = height,
+				Flags    = flags,
 				HasAlpha = hasAlpha
 			};
         }
@@ -110,7 +95,6 @@ namespace Chisel.Import.Source.VPKTools
 
             return scaledTexture;
         }
-#endif
 
         public static Color AverageTexture(Color[] pixels)
         {
@@ -138,6 +122,7 @@ namespace Chisel.Import.Source.VPKTools
                 plain[i] = mainColor;
             return plain;
         }
+#endif
 
         public static Frame[] LoadVTFFile(Stream stream, out int width, out int height, out VTFImageFlag flags, out bool hasAlpha)
 		{

--- a/ValveTextureFormat/VTF.cs
+++ b/ValveTextureFormat/VTF.cs
@@ -6,7 +6,6 @@ using Mathf = UnityEngine.Mathf;
 
 namespace Chisel.Import.Source.VPKTools
 {
-    // TODO: support multiple frames
     public class VTF
     {
         public static bool averageTextures = false;


### PR DESCRIPTION
1. Fixed DXT5 texture decompression by routing it through Texture2D (temp fix since this is slower)
2. Saving textures to disk no longer goes through Texture2D
3. Fixed VTF retrieving largest mip for texture at wrong location in stream
4. Added support to VTF to load multiple frames (VTF can hold multiple frames for a particular texture)
5. Improved generated LOD ranges a bit
6. Added support for multiple skins for the same model
7. Fixed model rotations so that imported models prefabs have their models upright instead of on their sides